### PR TITLE
adding support for implicit invalid votes in `ballots.json`

### DIFF
--- a/agora_tally/tally.py
+++ b/agora_tally/tally.py
@@ -16,7 +16,10 @@
 # along with agora-tally.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from agora_tally.voting_systems.base import get_voting_system_by_id, BlankVoteException
+from agora_tally.voting_systems.base import (
+    get_voting_system_by_id,
+    BlankVoteException
+)
 
 import copy
 import glob

--- a/agora_tally/voting_systems/borda.py
+++ b/agora_tally/voting_systems/borda.py
@@ -17,6 +17,7 @@ from .base import (
     BaseVotingSystem, 
     BaseTally, 
     WeightedChoice, 
+    ImplicitInvalidVoteException,
     get_key
 )
 
@@ -52,6 +53,7 @@ class BordaTally(BaseTally):
     def init(self):
         def custom_subparser(decoded_ballot, question, withdrawals):
             answers = set()
+            exception = None
 
             if 'bordas-max-points' not in question:
                 max_points = question['max']
@@ -78,7 +80,7 @@ class BordaTally(BaseTally):
             ]
             # - no position is repeated
             if len(selection) != len(set(selection)):
-                raise Exception()
+                exception = 'implicit'
 
             selection_sorted = sorted(selection)
             should_be_selection_sorted = [
@@ -87,10 +89,13 @@ class BordaTally(BaseTally):
             ]
             # - no missing position in-between
             if selection_sorted != should_be_selection_sorted:
-                raise Exception()
+                exception = 'implicit'
 
-            
-            return frozenset(answers)
+            ret_value = frozenset(answers)
+            if exception is None:
+                return ret_value
+            else:
+                raise ImplicitInvalidVoteException(ret_value)
 
         self.custom_subparser = custom_subparser
 


### PR DESCRIPTION
Up until now, implicit and explicit invalid votes were treated equally. The reason behind this was simple: all invalid votes end up in the electoral results counted as invalid and discarded for anything else, so there was no need to do anything else.

However, since we integrate with third-parties and provide the ballots for them to perform the tally themselves, a new need has arisen. They want to access to the content of the ballot, and decide for themselves if it is invalid or not and manage this process.

This PR implements this new feature, with the following changes and considerations:
- The `ballots.json` file now will now contain the decoded ballot selections, even if they are invalid.
- Within the `ballots.json` file, the `ballot. ballot_flags.null_vote` boolean flag indicates if a ballot was an explicit invalid ballot, and the `ballot. ballot_flags.implicit_null_vote` indicates if our tally system deemed that ballot invalid when the ballot was not explicitly set as such, because some restrictions on the ballot was violated.
- A explicit invalid mark has higher ranking than implicit, so if a ballot is both explicit and implicitly invalid, only the explicit `null_vote` mark will appear.
- In the `ballots.csv` file containing the ballots in CSV format, NULL_VOTE will always appear for any explicit and implicit ballot, but then the voter's selection will also appear as usual in the following columns.

An example of an implicit invalid cast vote extracted from `ballots.json` can be seen here:

```json
{
    "answer_total_votes_percentage":"over-total-valid-votes",
    "answers":[
      {
        "ballot_marks":1,
        "category":"",
        "details":"",
        "id":0,
        "questionid":"1001",
        "sort_order":0,
        "szid":"2004",
        "text":"August Macke",
        "total_count":0,
        "urls":[
          
        ],
        "wahlid":"111150"
      },
      {
        "category":"",
        "details":"",
        "id":1,
        "questionid":"1002",
        "sort_order":1,
        "szid":"2004",
        "text":"Frida Kahlo",
        "total_count":0,
        "urls":[
          
        ],
        "wahlid":"111150"
      },
      {
        "ballot_marks":1,
        "category":"Write-Ins",
        "details":"",
        "id":2,
        "isWriteIn":"true",
        "questionid":"2001",
        "sort_order":0,
        "szid":"2004",
        "text":"",
        "total_count":0,
        "urls":[
          
        ],
        "wahlid":"111150"
      },
      {
        "category":"Write-Ins",
        "details":"",
        "id":3,
        "isWriteIn":"true",
        "questionid":"2002",
        "sort_order":1,
        "szid":"2004",
        "text":"",
        "total_count":0,
        "urls":[
          
        ],
        "wahlid":"111150"
      },
      {
        "category":"",
        "details":"",
        "id":4,
        "invalidVoteFlag":"true",
        "questionid":"888",
        "sort_order":0,
        "szid":"2004",
        "text":"Mark vote as invalid",
        "total_count":0,
        "urls":[
          
        ],
        "wahlid":"111150"
      }
    ],
    "ballot_flags":{
      "blank_vote":false,
      "implicit_null_vote":true,
      "null_vote":false
    },
    "description":"<strong>Es d\u00fcrfen h\u00f6chstens 3 Bewerber:innen angekreuzt werden. Auf eine Bewerberin / Bewerber k\u00f6nnen bis zu 2 Stimmen abgegeben werden. Die Stimmen k\u00f6nnen auf Bewerbende verschiedener         Wahlvorschl\u00e4ge verteilt werden.</strong> <strong>Die Stimme f\u00fcr die Bewerberin/den Bewerber gilt auch zu Gunsten der gesamten Liste.</strong>",
    "election_index":0,
    "extra_options":{
      "accordion_folding_policy":"unfold-all",
      "cumulative_number_of_checkboxes":2,
      "enable_panachage":false,
      "invalid_vote_policy":"warn",
      "show_points":false,
      "shuffle_all_options":false,
      "shuffle_categories":false,
      "shuffle_category_list":[
        
      ]
    },
    "layout":"simultaneous-questions",
    "max":3,
    "min":0,
    "num_winners":3,
    "question_num":0,
    "tally_type":"cumulative",
    "title":"Fachbereichsrat Gestaltung / Gruppe der Studierenden"
  }
```