### PR TITLE
fix blank votes

### DIFF
--- a/tally_methods/voting_systems/base.py
+++ b/tally_methods/voting_systems/base.py
@@ -364,7 +364,11 @@ class BaseTally(object):
 
 
 class BlankVoteException(Exception):
-    pass
+    ballot = None
+
+    def __init__(self, ballot):
+        self.ballot = ballot
+        super().__init__()
 
 class ExplicitInvalidVoteException(Exception):
 


### PR DESCRIPTION
Blank votes were failing to register in ballots.json and were being registered as Null votes because of the changes made in https://github.com/sequentech/tally-methods/pull/64